### PR TITLE
Use tinyint(1) for boolean type definition.

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -437,7 +437,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function typeBoolean(Fluent $column)
     {
-        return 'tinyint';
+        return 'tinyint(1)';
     }
 
     /**


### PR DESCRIPTION
Using tinyint(1) instead of just tinyint for SQLite boolean type works better. SQLite doesn't natively support boolean data type. A tinyint field without a size could be an integer but when using tinyint(1) then it's much safer to treat this as boolean. 

Currently when I am running my app using MySql database I can easily identify my boolean fields with the type tinyint(1). However, when running my app using SQLite the same field shows up with type tinyint. So, basically getting different results when switching databases.
